### PR TITLE
i18n with react-intl and settings for PropTypes 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,72 +1,63 @@
 module.exports = {
-  "extends": ["airbnb"],
-  "parser": "babel-eslint",
-  "env": {
-    "browser": true,
-    "es6": true,
-    "node": true,
-    "jest": true
+  extends: ['airbnb'],
+  parser: 'babel-eslint',
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+    jest: true,
   },
-  "plugins": [
-    "react",
-    "jsx-a11y",
-    "import"
-  ],
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "jsx": true
-    }
+  plugins: ['react', 'jsx-a11y', 'import'],
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
-  "rules": {
-    "arrow-parens": 0,
-    "arrow-body-style": [
-      2,
-      "as-needed",
-    ],
-    "class-methods-use-this": 0,
-    "comma-dangle": [
-      2,
-      "always-multiline",
-    ],
-    "no-console": 1,
-    "prefer-template": 2,
-    "indent": [
+  rules: {
+    'arrow-parens': 0,
+    'arrow-body-style': [2, 'as-needed'],
+    'class-methods-use-this': 0,
+    'comma-dangle': [2, 'always-multiline'],
+    'no-console': 1,
+    'prefer-template': 2,
+    indent: [
       2,
       2,
       {
-        "SwitchCase": 1
-      }
+        SwitchCase: 1,
+      },
     ],
-    "max-len": 0,
-    "import/first": 0,
-    "import/no-unresolved": 2,
-    "import/prefer-default-export": 0,
-    "import/extensions": 0,
-    "import/no-named-as-default": 0,
-    "jsx-a11y/aria-props": 2,
-    "jsx-a11y/anchor-is-valid": 0,
-    "jsx-a11y/heading-has-content": 0,
-    "jsx-a11y/label-has-for": 2,
-    "jsx-a11y/role-has-required-aria-props": 2,
-    "jsx-a11y/role-supports-aria-props": 2,
-    "react/jsx-filename-extension": 0,
-    "react/require-extension": 0,
-    "react/require-default-props": 0,
-    "react/prefer-stateless-function": [
-      0, {
-        "ignorePureComponents": true
-      }
+    'max-len': 0,
+    'import/first': 0,
+    'import/no-unresolved': 2,
+    'import/prefer-default-export': 0,
+    'import/extensions': 0,
+    'import/no-named-as-default': 0,
+    'jsx-a11y/aria-props': 2,
+    'jsx-a11y/anchor-is-valid': 0,
+    'jsx-a11y/heading-has-content': 0,
+    'jsx-a11y/label-has-for': 2,
+    'jsx-a11y/role-has-required-aria-props': 2,
+    'jsx-a11y/role-supports-aria-props': 2,
+    'react/jsx-filename-extension': 0,
+    'react/require-extension': 0,
+    'react/require-default-props': 0,
+    'react/prefer-stateless-function': [
+      0,
+      {
+        ignorePureComponents: true,
+      },
     ],
-    "semi": 0,
-    "array-callback-return": 0
+    semi: 0,
+    'array-callback-return': 0,
   },
-  "settings": {
-    "import/resolver": {
-      "webpack": {
-        "config": "./webpack.config.js"
-      }
-    }
-  }
-}
+  settings: {
+    'import/resolver': {
+      webpack: {
+        config: './webpack.config.js',
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-import-resolver-webpack": "^0.10.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "react-intl": "^2.4.0",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "styled-components": "^4.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "babel-preset-stage-0": "^6.24.1",
     "eslint-import-resolver-webpack": "^0.10.1",
+    "prop-types": "^15.6.2",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^2.4.0",

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -24,7 +24,7 @@ class App extends PureComponent {
         <MainWrapper>
           <select onChange={this.setLocale}>
             <option value="en">English</option>
-            <option value="ja">Japan</option>
+            <option value="ja">Japanese</option>
           </select>
           <div className="col-md-4 offset-md-1">
             <h2>

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -19,7 +19,7 @@ class App extends PureComponent {
   render() {
     const { locale } = this.props;
     return (
-      <IntlProvider locale={locale} messages={messages[locale]}>
+      <IntlProvider locale={locale} messages={messages[locale]} key={locale}>
         <MainWrapper>
           <select onChange={this.setLocale}>
             <option value="en">English</option>

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import ListContainer from 'containers/ListContainer';
 import FormContainer from 'containers/FormContainer';
 import { addLocaleData, FormattedMessage, IntlProvider } from 'react-intl';
@@ -42,5 +43,10 @@ class App extends PureComponent {
     );
   }
 }
+
+App.propTypes = {
+  setLocale: PropTypes.func,
+  locale: PropTypes.string,
+};
 
 export default App;

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import ListContainer from 'containers/ListContainer';
 import FormContainer from 'containers/FormContainer';
 import MainWrapper from './MainWrapper';
@@ -6,11 +7,15 @@ import MainWrapper from './MainWrapper';
 const App = () => (
   <MainWrapper>
     <div className="col-md-4 offset-md-1">
-      <h2>Articles</h2>
+      <h2>
+        <FormattedMessage id="articles.header" />
+      </h2>
       <ListContainer />
     </div>
     <div className="col-md-4 offset-md-1">
-      <h2>Add a new article</h2>
+      <h2>
+        <FormattedMessage id="article.new" />
+      </h2>
       <FormContainer />
     </div>
   </MainWrapper>

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -10,11 +10,21 @@ import MainWrapper from './MainWrapper';
 addLocaleData([...en, ...ja]);
 
 class App extends PureComponent {
+  setLocale = event => {
+    const newLocale = event.target.value;
+    const { setLocale } = this.props;
+    setLocale(newLocale);
+  };
+
   render() {
     const { locale } = this.props;
     return (
       <IntlProvider locale={locale} messages={messages[locale]}>
         <MainWrapper>
+          <select onChange={this.setLocale}>
+            <option value="en">English</option>
+            <option value="ja">Japan</option>
+          </select>
           <div className="col-md-4 offset-md-1">
             <h2>
               <FormattedMessage id="articles.header" />

--- a/src/js/components/App/index.js
+++ b/src/js/components/App/index.js
@@ -1,24 +1,36 @@
-import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import React, { PureComponent } from 'react';
 import ListContainer from 'containers/ListContainer';
 import FormContainer from 'containers/FormContainer';
+import { addLocaleData, FormattedMessage, IntlProvider } from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import ja from 'react-intl/locale-data/ja';
+import messages from 'locales/messages';
 import MainWrapper from './MainWrapper';
 
-const App = () => (
-  <MainWrapper>
-    <div className="col-md-4 offset-md-1">
-      <h2>
-        <FormattedMessage id="articles.header" />
-      </h2>
-      <ListContainer />
-    </div>
-    <div className="col-md-4 offset-md-1">
-      <h2>
-        <FormattedMessage id="article.new" />
-      </h2>
-      <FormContainer />
-    </div>
-  </MainWrapper>
-);
+addLocaleData([...en, ...ja]);
+
+class App extends PureComponent {
+  render() {
+    const { locale } = this.props;
+    return (
+      <IntlProvider locale={locale} messages={messages[locale]}>
+        <MainWrapper>
+          <div className="col-md-4 offset-md-1">
+            <h2>
+              <FormattedMessage id="articles.header" />
+            </h2>
+            <ListContainer />
+          </div>
+          <div className="col-md-4 offset-md-1">
+            <h2>
+              <FormattedMessage id="article.new" />
+            </h2>
+            <FormContainer />
+          </div>
+        </MainWrapper>
+      </IntlProvider>
+    );
+  }
+}
 
 export default App;

--- a/src/js/components/Form/index.js
+++ b/src/js/components/Form/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import uuidvl from 'uuid';
+import { FormattedMessage } from 'react-intl';
 import {
   FormWrapper, InputWrapper, Input, Label, Button,
 } from './style';
@@ -27,7 +28,7 @@ class Form extends PureComponent {
       <FormWrapper onSubmit={this.handleSubmit}>
         <InputWrapper>
           <Label htmlFor="title">
-            Title:
+            <FormattedMessage id="article.title" />
             <Input
               type="text"
               className="form-control"

--- a/src/js/components/Form/index.js
+++ b/src/js/components/Form/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import uuidvl from 'uuid';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -18,7 +19,9 @@ class Form extends PureComponent {
     event.preventDefault();
     const { title } = this.state;
     const id = uuidvl();
-    this.props.addArticle({ title, id });
+    const { addArticle } = this.props;
+
+    addArticle({ title, id });
     this.setState({ title: '' });
   };
 
@@ -45,5 +48,9 @@ class Form extends PureComponent {
     );
   }
 }
+
+Form.propTypes = {
+  addArticle: PropTypes.func,
+};
 
 export default Form;

--- a/src/js/components/List/index.js
+++ b/src/js/components/List/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Article from './style';
 
 const List = ({ articles }) => (
@@ -10,5 +11,9 @@ const List = ({ articles }) => (
     ))}
   </ul>
 );
+
+List.propTypes = {
+  articles: PropTypes.arrayOf(Object),
+};
 
 export default List;

--- a/src/js/containers/AppContainer/actions.js
+++ b/src/js/containers/AppContainer/actions.js
@@ -1,4 +1,4 @@
-import SET_LOCALE from './constants';
+import { SET_LOCALE } from './constants';
 
 export const setLocale = locale => ({
   type: SET_LOCALE,

--- a/src/js/containers/AppContainer/actions.js
+++ b/src/js/containers/AppContainer/actions.js
@@ -1,0 +1,6 @@
+import SET_LOCALE from './constants';
+
+export const setLocale = locale => ({
+  type: SET_LOCALE,
+  payload: locale,
+});

--- a/src/js/containers/AppContainer/constants.js
+++ b/src/js/containers/AppContainer/constants.js
@@ -1,0 +1,1 @@
+export const SET_LOCALE = 'SET_LOCALE';

--- a/src/js/containers/AppContainer/index.js
+++ b/src/js/containers/AppContainer/index.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import App from 'components/App';
+import { setLocale } from './actions';
+
+const mapStateToProps = state => ({
+  locale: state.localeReducer.locale,
+});
+
+const mapDispatchToProps = dispatch => ({
+  addLocale: locale => dispatch(setLocale(locale)),
+});
+
+const AppContainer = connect(
+  mapStateToProps
+)(App);
+
+export default AppContainer;

--- a/src/js/containers/AppContainer/index.js
+++ b/src/js/containers/AppContainer/index.js
@@ -7,11 +7,12 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  addLocale: locale => dispatch(setLocale(locale)),
+  setLocale: locale => dispatch(setLocale(locale)),
 });
 
 const AppContainer = connect(
-  mapStateToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(App);
 
 export default AppContainer;

--- a/src/js/containers/AppContainer/reducer.js
+++ b/src/js/containers/AppContainer/reducer.js
@@ -1,4 +1,4 @@
-import SET_LOCALE from './constants';
+import { SET_LOCALE } from './constants';
 
 const initialState = {
   locale: 'en',
@@ -7,7 +7,10 @@ const initialState = {
 const localeReducer = (state = initialState, action) => {
   switch (action.type) {
     case SET_LOCALE:
-      return { ...state, locale: state.locale };
+      return {
+        ...state,
+        locale: action.payload,
+      };
     default:
       return state;
   }

--- a/src/js/containers/AppContainer/reducer.js
+++ b/src/js/containers/AppContainer/reducer.js
@@ -1,0 +1,16 @@
+import SET_LOCALE from './constants';
+
+const initialState = {
+  locale: 'en',
+};
+
+const localeReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_LOCALE:
+      return { ...state, locale: state.locale };
+    default:
+      return state;
+  }
+};
+
+export default localeReducer;

--- a/src/js/containers/ListContainer/index.js
+++ b/src/js/containers/ListContainer/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import List from 'components/List';
 
-const mapStateToProps = state => ({ articles: state.articles });
+const mapStateToProps = state => ({ articles: state.formReducer.articles });
 const ListContainer = connect(mapStateToProps)(List);
 
 export default ListContainer;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,12 +1,22 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
+import { addLocaleData, IntlProvider } from 'react-intl';
 import App from 'components/App';
+import en from 'react-intl/locale-data/en';
+import ja from 'react-intl/locale-data/ja';
+import messages from './locales/messages';
 import store from './store';
+
+addLocaleData([...en, ...ja]);
+
+const language = navigator.language.toLowerCase().split(/[-_]/)[0];
 
 render(
   <Provider store={store}>
-    <App />
+    <IntlProvider locale={language} messages={messages[language]}>
+      <App />
+    </IntlProvider>
   </Provider>,
   document.getElementById('app')
 );

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,22 +1,12 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { addLocaleData, IntlProvider } from 'react-intl';
-import App from 'components/App';
-import en from 'react-intl/locale-data/en';
-import ja from 'react-intl/locale-data/ja';
-import messages from './locales/messages';
+import AppContainer from 'containers/AppContainer';
 import store from './store';
-
-addLocaleData([...en, ...ja]);
-
-const language = navigator.language.toLowerCase().split(/[-_]/)[0];
 
 render(
   <Provider store={store}>
-    <IntlProvider locale={language} messages={messages[language]}>
-      <App />
-    </IntlProvider>
+    <AppContainer />
   </Provider>,
   document.getElementById('app')
 );

--- a/src/js/locales/messages.js
+++ b/src/js/locales/messages.js
@@ -1,0 +1,14 @@
+export default {
+  en: {
+    'article.new': 'Add a new article',
+    'article.title': 'Title',
+
+    'articles.header': 'Articles',
+  },
+  ja: {
+    'article.new': '記事を新規作成する',
+    'article.title': 'タイトル',
+
+    'articles.header': '記事一覧',
+  },
+};

--- a/src/js/locales/messages.js
+++ b/src/js/locales/messages.js
@@ -1,14 +1,14 @@
 export default {
   en: {
-    "article.new": "Add a new article",
-    "article.title": "Title",
+    'article.new': 'Add a new article',
+    'article.title': 'Title',
 
-    "articles.header": "Articles"
+    'articles.header': 'Articles',
   },
   ja: {
-    "article.new": "記事を新規作成する",
-    "article.title": "タイトル",
+    'article.new': '記事を新規作成する',
+    'article.title': 'タイトル',
 
-    "articles.header": "記事一覧"
-  }
+    'articles.header': '記事一覧',
+  },
 };

--- a/src/js/locales/messages.js
+++ b/src/js/locales/messages.js
@@ -1,14 +1,14 @@
 export default {
   en: {
-    'article.new': 'Add a new article',
-    'article.title': 'Title',
+    "article.new": "Add a new article",
+    "article.title": "Title",
 
-    'articles.header': 'Articles',
+    "articles.header": "Articles"
   },
   ja: {
-    'article.new': '記事を新規作成する',
-    'article.title': 'タイトル',
+    "article.new": "記事を新規作成する",
+    "article.title": "タイトル",
 
-    'articles.header': '記事一覧',
-  },
+    "articles.header": "記事一覧"
+  }
 };

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -1,6 +1,11 @@
 import formReducer from 'containers/FormContainer/reducer';
+import localeReducer from 'containers/AppContainer/reducer';
+import { combineReducers } from 'redux';
 
-const rootReducer = formReducer;
+const rootReducer = combineReducers({
+  formReducer,
+  localeReducer,
+})
 // rootReducer will be combined reducer if I implement more reducers
 
 export default rootReducer;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = {
     alias: {
       components: path.join(__dirname, 'src/js/components'),
       containers: path.join(__dirname, 'src/js/containers'),
+      locales: path.join(__dirname, 'src/js/locales'),
     },
     extensions: ['.webpack.js', '.web.js', '.js', '.yml', '.style.js'],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,6 +3654,26 @@ interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
+intl-format-cache@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
+
+intl-messageformat-parser@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
+
+intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
+  dependencies:
+    intl-messageformat-parser "1.4.0"
+
+intl-relativeformat@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz#010f1105802251f40ac47d0e3e1a201348a255df"
+  dependencies:
+    intl-messageformat "^2.0.0"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -3661,7 +3681,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -5621,6 +5641,15 @@ react-dom@^16.5.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     schedule "^0.3.0"
+
+react-intl@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.4.0.tgz#66c14dc9df9a73b2fbbfbd6021726e80a613eb15"
+  dependencies:
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^2.1.0"
+    intl-relativeformat "^2.0.0"
+    invariant "^2.1.1"
 
 react-is@^16.3.1, react-is@^16.3.2:
   version "16.5.0"


### PR DESCRIPTION
# What
- i18n with react-intl (English and Japanese)
- Add PropTypes definition to comoponents

# How I implemented

### i18n
- Add react-intl library
- Define locales/messages.js as translation file for each language
- Create localeReducer, which is connected to `AppContainer`  `App` component
- Change react-intl's locale by `App` components' props `locale`

### PropTypes
- Add prop-types library
- Define PropTypes in some components that contain props